### PR TITLE
Add GitHub Actions workflow to auto-fix Dependabot lockfile

### DIFF
--- a/.github/workflows/dependabot-fix-lockfile.yml
+++ b/.github/workflows/dependabot-fix-lockfile.yml
@@ -1,0 +1,46 @@
+name: Fix Dependabot lockfile
+
+on:
+  pull_request:
+    branches: [main, next]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  fix-lockfile:
+    name: Fix lockfile
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+
+      - name: Regenerate lockfile
+        run: npm install --package-lock-only --ignore-scripts
+
+      - name: Commit updated lockfile
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json
+          if git diff --cached --quiet; then
+            echo "Lockfile is already in sync"
+          else
+            git commit -m "fix: regenerate package-lock.json"
+            git push
+          fi


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically regenerates and commits the `package-lock.json` file when Dependabot creates pull requests. This ensures the lockfile stays in sync with `package.json` changes.

## Key Changes
- Added `.github/workflows/dependabot-fix-lockfile.yml` workflow that:
  - Triggers on pull requests to `main` and `next` branches
  - Only runs when the PR author is `dependabot[bot]`
  - Checks out the PR branch with write permissions
  - Sets up Node.js 22
  - Regenerates the lockfile using `npm install --package-lock-only --ignore-scripts`
  - Commits and pushes the updated lockfile if changes are detected
  - Uses hardened runner for security auditing

## Implementation Details
- The workflow uses a conditional check to only run on Dependabot PRs, preventing unnecessary executions
- It includes a safety check to only commit if the lockfile actually changed
- Uses GitHub Actions bot credentials for commits to maintain proper attribution
- Includes security hardening via step-security/harden-runner with audit-level egress policy

https://claude.ai/code/session_01W2qSm36L1wLHWQZyqn8ywy